### PR TITLE
Add a wrapper script for calling individual scripts more easily

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
           useradd -m gevhaz
           chown gevhaz:gevhaz . --recursive
           pacman -Syu --noconfirm
-          pacman -S git fakeroot binutils --noconfirm
+          pacman -S git fakeroot binutils debugedit --noconfirm
       - name: Update package version in PKGBUILD
         if: inputs.package_version != ''
         run: |

--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ Here are explanations of the scripts, together with example output. If
 you cannot see the icons, it means you don't use Nerd Font in your
 browser.
 
+## sb
+
+This script is a wrapper for all the other scripts.
+
+The script is only usable if sb-scripts is installed as a system package. You
+can install it this way for Arch Linux by running `makepkg` in `packaging/arch`,
+and it will build the package based on the `PKGBUID` file you find there. You
+can then install it with `pacman -U`.
+
+Once you have this script, you can use it to run the other scripts. Instead of
+running, for example, `sb-bat`, you'd run `sb bat`, or instead of `./sb-net-vpn
+<interface-name>`, you'd run `sb net-vpn <interface-name>`.
+
 ## sb-bat
 
 Shows percentage battery left and charge status if supported. Example of

--- a/README.md
+++ b/README.md
@@ -128,9 +128,10 @@ Example of correct output:
 
 ## sb-net-vpn
 
-Show's whether you're connected to a network and a vpn. You might need
-to grep for different strings. Check what's right for your computer with
-`ip a`. Example of correct output:
+Show's whether you're connected to a network and a vpn. Takes one argument,
+which is a string that will only be found in the `ip a` output if you are
+connected to your VPN. That is, the name of your VPN/WireGuard interface.
+Example of correct output:
 
 ```
 
@@ -200,9 +201,9 @@ correct output:
 
 ## sb-vpn
 
-Shows if vpn is connected. You might need to change what the script
-greps for to fit with your own available connections. Example of correct
-output:
+Shows if vpn is connected. Takes one argument, which is a string that will only
+be found in the `ip a` output if you are connected to your VPN. That is, the
+name of your VPN/WireGuard interface. Example of correct output:
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -210,9 +210,10 @@ output:
 
 ## sb-weather
 
-Shows weather information from yr.no. You have to change the coordinates
-in the script to fit with your local settings. Example of correct
-output:
+Shows weather information from yr.no. You have to provide coordinates as
+arguments – first the latitude of the place where you want to see the weather,
+then the longitude. There is no limit on how specific the coordinates need to be
+with regards to decimals. Example of correct output:
 
 ```
 +4°C 

--- a/sb
+++ b/sb
@@ -2,8 +2,8 @@
 
 : "${SCRIPTS_DIR:=/opt/sb-scripts}"
 
-if [ $# -ne 1 ]; then
-    printf "sb takes exactly one argument\n"
+if [ $# -lt 1 ]; then
+    printf "sb needs at least one argument\n"
     exit 1
 fi
 
@@ -19,4 +19,6 @@ if [ ! -x "$SCRIPTS_DIR/$SCRIPT_NAME" ]; then
     exit 1
 fi
 
-exec "$SCRIPTS_DIR/$SCRIPT_NAME"
+shift
+
+exec "$SCRIPTS_DIR/$SCRIPT_NAME" "$@"

--- a/sb-net-vpn
+++ b/sb-net-vpn
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-vpn_connections=$(ip a | grep vpn | grep -c inet)
+VPN_INTERFACE_NAME="${1:?Error: an interface name must be provided as the first argument}"
+
+vpn_connections=$(ip a | grep "$VPN_INTERFACE_NAME" | grep -c inet)
 if [[ $vpn_connections -lt 1 ]]; then
 	echo -e "\x0d\x0b"
     exit 0

--- a/sb-vpn
+++ b/sb-vpn
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-connections=$(ip a | grep vpn80 | grep -c inet)
+VPN_INTERFACE_NAME="${1:?Error: an interface name must be provided as the first argument}"
+
+connections=$(ip a | grep "$VPN_INTERFACE_NAME" | grep -c inet)
 if [[ $connections -eq 1 ]]; then
 	# echo "VPN: On"
 	echo ""

--- a/sb-weather
+++ b/sb-weather
@@ -1,14 +1,12 @@
 #! /bin/bash
 
-# Change the coordinates in the url if you want weather data for another
-# location.
-weather_data_lund=$(curl -A "sb-weather/0.1" -s "https://api.met.no/weatherapi/locationforecast/2.0/compact?lat=55.7179&lon=13.20798")
+# The coordinates sent to YR.
+LATITUDE="${1:?Error: First argument must be latitude where to check weather}"
+LONGITUDE="${2:?Error: Second argument must be longitude where to check weather}"
+
+weather_data_lund=$(curl -A "sb-weather/0.1" -s "https://api.met.no/weatherapi/locationforecast/2.0/compact?lat=${LATITUDE}&lon=${LONGITUDE}")
 today_weather=$(echo "${weather_data_lund}" | jq -r '.properties.timeseries[0].data.next_6_hours.summary.symbol_code')
 today_temp=$(echo "${weather_data_lund}" | jq -r '.properties.timeseries[0].data.instant.details.air_temperature')
-# today_time=$(echo "${weather_data_lund}" | jq -r '.properties.timeseries[0].time')
-# tomorrow_weather=$(echo "${weather_data_lund}" | jq -r '.properties.timeseries[24].data.next_12_hours.summary.symbol_code')
-# tomorrow_time=$(echo "${weather_data_lund}" | jq -r '.properties.timeseries[24].time')
-# tomorrow_temp=$(echo "${weather_data_lund}" | jq -r '.properties.timeseries[24].data.instant.details.air_temperature')
 
 round() {
 	round_n=$(echo "$1" | awk '{print ($0>0)?(($0-int($0)<0.5)?int($0):(int($0)+1)):((int($0)-$0<0.5)?int($0):int($0)-1)}')


### PR DESCRIPTION
The wrapper script is used when using a system installation of sb-scripts. It avoids cluttering the PATH namespace with too many scripts.