### PR TITLE
Truncate output text of sb-tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,14 +151,14 @@ colors for higher usage.
 ```
 ## sb-tasks
 
-This shows information about your [Taskwarrior](taskwarrior.org/) tasks.
-First number is the number of tasks due today, second is the number of
-overdue tasks, and third is the number of tasks completed today. It also
-shows rolling text of the active task, or otherwise the highest urgency
-task if there is one. Example of correct output:
+This shows information about your [Taskwarrior](taskwarrior.org/) tasks. First
+number is the number of tasks due today, second is the number of overdue tasks,
+and third is the number of tasks completed today. It also shows truncated text
+of the active task, or otherwise the highest urgency task if there is one.
+Example of correct output:
 
 ```
- 4 鬒 9  0 | task » the started
+ 4 鬒 9  0 | started ta…
 ```
 
 "Today" is considered over at 4 in the morning the next day.

--- a/sb-tasks
+++ b/sb-tasks
@@ -7,19 +7,15 @@ yellow="\x0f"
 orange="\x0e"
 # red="\x0d"
 
-text_length=20
+text_length=10
 
-rolling_text() {
+cut_text() {
     text=$1
     max_length=$2
     text_length=${#text}
     if [[ $text_length -ge $max_length ]]; then
-        time=$(awk '{print int($1) + 1000}' /proc/uptime)
-        time=$((time % max_length))
-        text="${text} » ${text}"
-        text=${text:time}
         text=${text::max_length}
-        printf "%s" "$text"
+        printf "%s…" "$(echo "$text" | xargs)"
     else
         printf "%s" "$text"
     fi
@@ -44,10 +40,10 @@ n_active_tasks="$(task +ACTIVE export | jq 'length')"
 highest_prio_task="$(task status:pending export | jq -r 'max_by(.urgency) | .description')"
 
 if [ "$n_active_tasks" -ne 0 ]; then
-    rolling=$(rolling_text "$highest_prio_task" "$text_length")
+    rolling=$(cut_text "$highest_prio_task" "$text_length")
     colored_rolling=$(printf "%s%s%s" "${green}" "${rolling}" "${default}")
 elif [ -n "$highest_prio_task" ]; then
-    rolling=$(rolling_text "$highest_prio_task" "$text_length")
+    rolling=$(cut_text "$highest_prio_task" "$text_length")
     colored_rolling=$(printf "%s%s%s" "${yellow}" "${rolling}" "${default}")
 fi
 echo -ne "$task_numbers | $colored_rolling"


### PR DESCRIPTION
"Rolling text" is less appropriate for sb-tasks because it cannot update
every second. This patch changes it from rolling text to a truncated
text, with an elipisis at the end of it is truncated but not otherwise.
